### PR TITLE
eliminate per-pop allocations in ordered queue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,7 @@ build/
 
 # debug information files
 *.dwo
+
+# profiling
+perf
+perf.*

--- a/Makefile
+++ b/Makefile
@@ -43,4 +43,6 @@ run-tests:
 test: build-tests run-tests
 
 clean:
-	@rm -rf $(BUILD_DIR)
+	-@rm -rf $(BUILD_DIR)
+	-@rm *.out
+	-@rm perf.*

--- a/include/scheduler/ordered_queue.h
+++ b/include/scheduler/ordered_queue.h
@@ -65,10 +65,10 @@ public:
         return;
     }
 
-    std::shared_ptr<T> wait_and_pop() {
+    T wait_and_pop() {
         while (true) {
             std::unique_lock<std::mutex> lk(mtx);
-            if (heap.empty() && shutdown_) return std::shared_ptr<T>();
+            if (heap.empty() && shutdown_) return {};
     
             if (heap.empty()) {
                 data_cond.wait(lk, [this] { return !heap.empty() || shutdown_; });
@@ -86,12 +86,12 @@ public:
             }
 
             std::pop_heap(heap.begin(), heap.end(), cmp);
-            auto res {std::make_shared<T>(std::move(heap.back()))};
+            auto res {std::move(heap.back())};
             heap.pop_back();
             return res;
         }
 
-        return std::shared_ptr<T>();
+        return {};
     }
 
     bool try_pop(T& value) {
@@ -110,17 +110,17 @@ public:
         return true;
     }
 
-    std::shared_ptr<T> try_pop() {
+    std::optional<T> try_pop() {
         std::lock_guard<std::mutex> lk(mtx);
 
-        if (heap.empty()) return std::shared_ptr<T>();
+        if (heap.empty()) return std::nullopt;
 
         auto &next = heap.front();
         auto now = std::chrono::steady_clock::now();
-        if (next.scheduled_at > now) return std::shared_ptr<T>();
+        if (next.scheduled_at > now) return std::nullopt;
 
         std::pop_heap(heap.begin(), heap.end(), cmp);
-        auto res {std::make_shared<T>(std::move(heap.back()))};
+        auto res {std::move(heap.back())};
         heap.pop_back();
 
         return res;

--- a/include/scheduler/scheduler.h
+++ b/include/scheduler/scheduler.h
@@ -45,7 +45,8 @@ public:
 protected:
     Scheduler(std::unique_ptr<detail::IThreadPool> thread_pool,
         std::unique_ptr<detail::IStatisticsCalculator> stats);
-    uint64_t calculatePriority(int priority, std::optional<std::chrono::steady_clock::time_point> deadline);
+    uint64_t calculatePriority(int priority,
+        std::optional<std::chrono::steady_clock::time_point> deadline, std::chrono::steady_clock::time_point now);
 
 private:
     std::unique_ptr<detail::IThreadPool> thread_pool;

--- a/main.cpp
+++ b/main.cpp
@@ -24,7 +24,7 @@ void runBasicSchedulingTests(scheduler::Scheduler& scheduler,
         // spdlog::info("One-off Task #{} executed.", count); //disabled for better speed
     };
     // Schedule a high-frequency recurring task
-    scheduler.scheduleRecurring(job_rec, /*priority=*/5, 1ms);
+    // scheduler.scheduleRecurring(job_rec, /*priority=*/5, 1ms);
 
     // Schedule one-off tasks with varying priorities and deadlines
     for (int i = 0; i < 10; ++i) {
@@ -89,19 +89,22 @@ int main() {
     // Atomic counter for executed tasks
     auto executions = std::make_shared<std::atomic<uint64_t>>(0);
 
-    concurrencyTest(scheduler, executions, /*numProducers=*/4, /*tasksPerProducer=*/2000);
     runBasicSchedulingTests(scheduler, executions);
+    // concurrencyTest(scheduler, executions, /*numProducers=*/1, /*tasksPerProducer=*/2000);
+    std::this_thread::sleep_for(std::chrono::seconds(2));
+
+    concurrencyTest(scheduler, executions, /*numProducers=*/8, /*tasksPerProducer=*/100000);
 
     // Allow tasks to execute for a fixed duration
-    std::this_thread::sleep_for(2s);
+    std::this_thread::sleep_for(20s);
 
     auto [average, minimum, maximum] = scheduler.getLatencyStatistics();
     uint64_t missed = scheduler.getMissedTasks();
 
     spdlog::info("=== Scheduler Latency Results ===");
-    spdlog::info("Average Latency: {} μs", average);
-    spdlog::info("Minimum Latency: {} μs", minimum);
-    spdlog::info("Maximum Latency: {} μs", maximum);
+    spdlog::info("Average Latency: {} ns", average);
+    spdlog::info("Minimum Latency: {} ns", minimum);
+    spdlog::info("Maximum Latency: {} ns", maximum);
     spdlog::info("Missed tasks: {} out of {}", missed, executions->load());
 
     return 0;

--- a/src/scheduler.cpp
+++ b/src/scheduler.cpp
@@ -45,7 +45,7 @@ void Scheduler::schedule(std::function<void()> job, int priority,
     auto now = steady_clock::now();
     auto t = [this, job = std::move(job), enqueue_time = now, deadline]() mutable {
             auto start = steady_clock::now();
-            statistics->updateLatencyStatistics(std::chrono::duration_cast<std::chrono::microseconds>(start - enqueue_time).count());
+            statistics->updateLatencyStatistics(std::chrono::duration_cast<std::chrono::nanoseconds>(start - enqueue_time).count());
             if (deadline && start > *deadline)
                 missed_tasks.fetch_add(1, std::memory_order_relaxed);
 
@@ -59,7 +59,7 @@ void Scheduler::schedule(std::function<void()> job, int priority,
 
     Task task{
         std::move(t), //job
-        calculatePriority(priority, deadline), //priority
+        calculatePriority(priority, deadline, now), //priority
         seq, //sequence_number
         now, // scheduled_at
         std::chrono::milliseconds{0}, // interval
@@ -76,12 +76,10 @@ void Scheduler::scheduleRecurring(std::function<void()> job, int priority,
 {
     if (!job) return;
 
-    // schedule(job, priority, std::nullopt); // fire instantly once
-
     auto now = steady_clock::now();
     auto t = [this, job = std::move(job), enqueue_time = now, priority, interval]() mutable {
             auto start = steady_clock::now();
-            statistics->updateLatencyStatistics(std::chrono::duration_cast<std::chrono::microseconds>(start - enqueue_time).count());
+            statistics->updateLatencyStatistics(std::chrono::duration_cast<std::chrono::nanoseconds>(start - enqueue_time).count());
 
             try {
                 job();
@@ -94,7 +92,7 @@ void Scheduler::scheduleRecurring(std::function<void()> job, int priority,
 
     Task task{
         std::move(t), //job
-        calculatePriority(priority, std::nullopt), //priority
+        calculatePriority(priority, std::nullopt, now), //priority
         seq, //sequence_number
         now + interval, // scheduled_at
         interval, // interval
@@ -114,10 +112,12 @@ uint64_t Scheduler::getMissedTasks() {
 }
 
 // this is a static way of handling tasks that are in danger of reaching their deadline.
-uint64_t Scheduler::calculatePriority(int priority, std::optional<std::chrono::steady_clock::time_point> deadline) {
+uint64_t Scheduler::calculatePriority(int priority,
+    std::optional<std::chrono::steady_clock::time_point> deadline, steady_clock::time_point now)
+{
     priority = std::clamp(priority, 0, BASE_MAX);
 
-    if (deadline && (*deadline - steady_clock::now() <= imminent_time)) return BASE_MAX + BOOST + priority;
+    if (deadline && (*deadline - now <= imminent_time)) return BASE_MAX + BOOST + priority;
 
     return priority;
 }

--- a/test/src/unit/test_scheduler.cpp
+++ b/test/src/unit/test_scheduler.cpp
@@ -60,28 +60,17 @@ TEST_F(TestScheduler, EnqueueOneOffTaskPushesReadyQueue) {
     sched->schedule([](){}, 5, std::nullopt);
 }
 
-// TEST_F(TestScheduler, RecurringTaskPushesReadyOnce) {
-//     EXPECT_CALL(*rawThreadPool, stop).Times(::testing::AtLeast(1));
-//     sched->scheduleRecurring([](){}, 1, std::chrono::milliseconds{100});
-// }
-
-// TEST_F(TestScheduler, DispatchLoopSchedulesRecurringTask) {
-
-//     EXPECT_CALL(*rawThreadPool, stop).Times(::testing::AtLeast(1));
-//     // We expect dispatch to call thread_pool.enqueue once
-
-// }
-
 TEST_F(TestScheduler, BoostsWhenDeadlineIsImminent) {
     using namespace std::chrono;
 
     // Arrange
     // priority to test and a deadline exactly at the imminent_time threshold (10ms)
     const int priority = 50;
+    const auto now = std::chrono::steady_clock::now();
     const auto deadline = std::chrono::steady_clock::now() + microseconds{10};
 
     // Act
-    uint64_t result = sched->calculatePriority(priority, deadline);
+    uint64_t result = sched->calculatePriority(priority, deadline, now);
 
     // Assert
     // BASE_MAX = 100, BOOST = 1000, so we expect 100 + 1000 + 50 = 1150
@@ -94,10 +83,11 @@ TEST_F(TestScheduler, DoesNotBoostsWhenDeadlineIsImminent) {
     // Arrange
     // priority to test and a deadline exactly at the imminent_time threshold (10ms)
     const int priority = 50;
-    const auto deadline = std::chrono::steady_clock::now() + microseconds{1000};
+    const auto now = std::chrono::steady_clock::now();
+    const auto deadline = now + microseconds{1000};
 
     // Act
-    uint64_t result = sched->calculatePriority(priority, deadline);
+    uint64_t result = sched->calculatePriority(priority, deadline, now);
 
     // Assert
     // BASE_MAX = 100, BOOST = 1000, so we expect 100 + 1000 + 50 = 1150

--- a/test/src/unit/test_task_queue.cpp
+++ b/test/src/unit/test_task_queue.cpp
@@ -35,9 +35,9 @@ TEST(OrderedQueue, InsertArecurringTask) {
 
     q.push(t);
 
-    auto rsp = q.try_pop();
+    std::optional<Task> rsp = q.try_pop();
 
-    EXPECT_EQ(rsp, nullptr);
+    EXPECT_EQ(rsp, std::nullopt);
 
     rsp = q.wait_and_pop();
 
@@ -113,6 +113,6 @@ TEST(OrderedQueue, TestQueueShorting) {
     auto r3 = q.wait_and_pop();
     auto r4 = q.wait_and_pop();
 
-    EXPECT_EQ(t3, *r3);
-    EXPECT_EQ(t4, *r4);
+    EXPECT_EQ(t3, r3);
+    EXPECT_EQ(t4, r4);
 }


### PR DESCRIPTION
perf showed malloc/free/_Sp_counted_* ~15% of samples
Reduce latency variance from allocator stalls

Replace make_shared on pop with by-value return (std::optional<Task>)